### PR TITLE
refactor: deploy eigen service manager in compose

### DIFF
--- a/.github/workflows/changelog_reminder.yml
+++ b/.github/workflows/changelog_reminder.yml
@@ -14,6 +14,8 @@ jobs:
     if: "!github.event.pull_request.draft && !contains(github.event.pull_request.title, 'revert') && !contains(github.event.pull_request.title, 'test') && !contains(github.event.pull_request.title, 'chore') && !contains(github.event.pull_request.title, 'ci') && !contains(github.event.pull_request.title, 'docs') && !contains(github.event.pull_request.title, 'style') && !contains(github.event.pull_request.title, 'build') && !contains(github.event.pull_request.title, 'refactor')"
     steps:
       - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
       - uses: mskelton/changelog-reminder-action@v3
         with:
           message: "@${{ github.actor }} your pull request is missing a changelog!"

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ make wasi-build
 # wavs-cli exec --component $(pwd)/compiled/eth_price_oracle.wasm --input `cast format-bytes32-string 1`
 ```
 
-## Deploy Service and Verify
+## Deploy Service
 
 ```bash
 # Contract trigger function signature to listen for
@@ -103,10 +103,15 @@ wavs-cli deploy-service --log-level=error --data /data/.docker/cli --home /data 
     --trigger-address ${TRIGGER_ADDR} \
     --submit-address ${SERVICE_HANDLER_ADDR} \
     --service-config '{"fuel_limit":100000000,"max_gas":5000000,"host_envs":[],"kv":[],"workflow_id":"default","component_id":"default"}'
+```
 
-# Submit AVS request -> chain
+## Submit Request and Verify
+
+```bash
+# Submit request -> chain
 cast send ${TRIGGER_ADDR} "addTrigger(bytes)" `cast format-bytes32-string 1` --rpc-url http://localhost:8545 --private-key $FOUNDRY_ANVIL_PRIVATE_KEY
 
+# Verify
 ID=`cast call ${TRIGGER_ADDR} "nextTriggerId()" --rpc-url http://localhost:8545`; echo "ID: $ID"
 cast --to-ascii $(cast decode-abi "getData(uint64)(bytes)" `cast call ${SERVICE_HANDLER_ADDR} "getData(uint64)" $ID`)
 ```

--- a/README.md
+++ b/README.md
@@ -68,9 +68,6 @@ make start-all
 sudo chmod 0666 .docker/cli/deployments.json
 alias wavs-cli="docker run --network host --env-file ./.env -v $(pwd):/data ghcr.io/lay3rlabs/wavs:0.3.0-alpha5 wavs-cli"
 
-# Deploy service-manager
-wavs-cli deploy-eigen-service-manager --data /data/.docker/cli --home /data
-
 # Deploy contracts
 export SERVICE_MANAGER=`jq -r '.eigen_service_managers.local | .[-1]' .docker/cli/deployments.json`
 export FOUNDRY_ANVIL_PRIVATE_KEY=0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -61,3 +61,17 @@ services:
       - "./:/wavs"
       - "./.docker/cli:/root/wavs/cli/"
     network_mode: "host"
+
+  deploy-eigenlayer-service-manager:
+    image: "ghcr.io/lay3rlabs/wavs:0.3.0-alpha5"
+    container_name: "wavs-deploy-service-manager"
+    depends_on:
+      deploy-eigenlayer:
+        condition: service_completed_successfully
+    restart: "no"
+    env_file: "./.env"
+    command: ["wavs-cli", "deploy-eigen-service-manager"]
+    volumes:
+      - "./:/wavs"
+      - "./.docker/cli:/root/wavs/cli/"
+    network_mode: "host"


### PR DESCRIPTION
Deploys the eigen-service manager when deploy-eigenlayer finishes

ref: "Now that we have the inversion in, maybe "start-all" should also deploy the manager, so the user only has to really think about deploying their business logic? (similarly the section about the manager could be renamed "Upload your WAVS Service Handler" - david