### PR TITLE
fix: `makefile` ohmyzsh not trapping kill signal for anvil

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,10 +62,10 @@ setup:
 ## start-all: starting anvil and WAVS with docker compose
 start-all: clean-docker
 	@rm .docker/*.json || true
-	@trap 'kill $(jobs -pr)' EXIT
 # running anvil out of compose is a temp work around for MacOS
 	@anvil &
 	@docker compose up
+	@trap 'killall -9 anvil' EXIT
 	@wait
 
 ## deploy-contracts: deploying the contracts | SERVICE_MANAGER_ADDR, RPC_URL


### PR DESCRIPTION
closes #38

Still need to very on my machine to reproduce

## Works on
- [x] Linux
- [ ] macOS (bash)
- [ ] MacOS (zsh)
- [ ] MacOS (ohmyzsh)