### PR TITLE
Auto-delete wavs-cli containers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ SERVICE_CONFIG='{"fuel_limit":100000000,"max_gas":5000000,"host_envs":[],"kv":[]
 
 # Define common variables
 CARGO=cargo
-WAVS_CMD ?= $(SUDO) docker run --network host $$(test -f .env && echo "--env-file ./.env") -v $$(pwd):/data ghcr.io/lay3rlabs/wavs:0.3.0-alpha9 wavs-cli
+WAVS_CMD ?= $(SUDO) docker run --rm --network host $$(test -f .env && echo "--env-file ./.env") -v $$(pwd):/data ghcr.io/lay3rlabs/wavs:0.3.0-alpha9 wavs-cli
 ANVIL_PRIVATE_KEY?=0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
 RPC_URL?=http://localhost:8545
 SERVICE_MANAGER_ADDR?=`jq -r '.eigen_service_managers.local | .[-1]' .docker/deployments.json`


### PR DESCRIPTION
After running the tutorial and stopping the `make start-all`, I get the following

```
$ docker ps -a 
CONTAINER ID   IMAGE                                 COMMAND                  CREATED             STATUS                         PORTS     NAMES
04185f1559fa   ghcr.io/lay3rlabs/wavs:0.3.0-alpha9   "wavs-cli exec --log…"   About an hour ago   Exited (0) About an hour ago             relaxed_wright
c3973b5dcb3d   ghcr.io/lay3rlabs/wavs:0.3.0-alpha9   "wavs-cli deploy-ser…"   About an hour ago   Exited (0) About an hour ago             hopeful_tharp
d63996f1a83e   ghcr.io/lay3rlabs/wavs:0.3.0-alpha9   "wavs-cli deploy-eig…"   About an hour ago   Exited (0) About an hour ago             wavs-deploy-service-manager
d1f471eea5e6   ghcr.io/lay3rlabs/wavs:0.3.0-alpha9   "wavs-cli deploy-eig…"   About an hour ago   Exited (0) About an hour ago             wavs-deploy-eigenlayer
5d1f1fe1429c   ghcr.io/lay3rlabs/wavs:0.3.0-alpha9   "wavs-aggregator"        About an hour ago   Exited (137) 2 minutes ago               wavs-aggregator
e3b6050d6e54   ghcr.io/lay3rlabs/wavs:0.3.0-alpha9   "wavs"                   About an hour ago   Exited (137) 2 minutes ago               wavs
e
```

I know there is a `clean-docker` command that is great for longer lived containers like wavs and wavs-aggregator, where we may want to potentially connect and debug. 

However, there is no need to accumulate `wavs-cli` containers for each execution we do. Simply adding the `docker run --rm` flag will delete the containers fully after they execute, leaving everything a bit cleaner