### PR TITLE
bump deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,9 +25,9 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "alloy-chains"
-version = "0.1.59"
+version = "0.1.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d37bc62b68c056e3742265ab73c73d413d07357909e0e4ea1e95453066a7469"
+checksum = "3a754dbb534198644cb8355b8c23f4aaecf03670fb9409242be1fa1e25897ee9"
 dependencies = [
  "alloy-primitives",
  "num_enum",
@@ -36,9 +36,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce20c85f6b24a5da40b2350a748e348417f0465dedbb523a4d149143bc4a41ce"
+checksum = "69e32ef5c74bbeb1733c37f4ac7f866f8c8af208b7b4265e21af609dcac5bd5e"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -53,9 +53,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus-any"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e23af02ccded0031ef2b70df4fe9965b1c742c5d5384c8c767ae0311f7e62b9"
+checksum = "0fa13b7b1e1e3fedc42f0728103bfa3b4d566d3d42b606db449504d88dbdbdcf"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -102,9 +102,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-eips"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7149e011edbd588f6df6564b369c75f6b538d76db14053d95e0b43b2d92e4266"
+checksum = "5591581ca2ab0b3e7226a4047f9a1bfcf431da1d0cce3752fda609fea3c27e37"
 dependencies = [
  "alloy-eip2124",
  "alloy-eip2930",
@@ -134,9 +134,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-rpc"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0c5c9651fd20a2fd4a57606b6a570d1c17ab86e686b962b2f1ecac68b51e020"
+checksum = "762414662d793d7aaa36ee3af6928b6be23227df1681ce9c039f6f11daadef64"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -148,9 +148,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-network"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b02ed56783fb2c086a4ac8961175dd6d3ad163e6cf6125f0b83f7de03379b607"
+checksum = "8be03f2ebc00cf88bd06d3c6caf387dceaa9c7e6b268216779fa68a9bf8ab4e6"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -173,9 +173,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-network-primitives"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0624cfa9311aa8283cd3bf5eed883d0d1e823e2a4d57b30e1b49af4b3678a6b"
+checksum = "3a00ce618ae2f78369918be0c20f620336381502c83b6ed62c2f7b2db27698b0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -213,9 +213,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-provider"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07c68df5354225da542efeb6d9388b65773b3304309b437416146e9d1e2bc1bd"
+checksum = "cbe0a2acff0c4bd1669c71251ce10fc455cbffa1b4d0a817d5ea4ba7e5bb3db7"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -226,6 +226,7 @@ dependencies = [
  "alloy-primitives",
  "alloy-rpc-client",
  "alloy-rpc-types-eth",
+ "alloy-sol-types",
  "alloy-transport",
  "alloy-transport-http",
  "async-stream",
@@ -271,9 +272,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-client"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0371aae9b44a35e374c94c7e1df5cbccf0f52b2ef7c782291ed56e86d88ec106"
+checksum = "b37cc3c7883dc41be1b01460127ad7930466d0a4bb6ba15a02ee34d2745e2d7c"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -294,9 +295,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-any"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66e119337400d8b0348e1576ab37ffa56d1a04cbc977a84d4fa0a527d7cb0c21"
+checksum = "318ae46dd12456df42527c3b94c1ae9001e1ceb707f7afe2c7807ac4e49ebad9"
 dependencies = [
  "alloy-consensus-any",
  "alloy-rpc-types-eth",
@@ -305,9 +306,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-eth"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a4a43d8b1344e3ef115ed7a2cee934876e4a64d2b9d9bee8738f9806900757e"
+checksum = "8b4dbee4d82f8a22dde18c28257bed759afeae7ba73da4a1479a039fd1445d04"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -325,9 +326,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-serde"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86aa42c36e3c0db5bd9a7314e98aa261a61d5e3d6a0bd7e51fb8b0a3d6438481"
+checksum = "8732058f5ca28c1d53d241e8504620b997ef670315d7c8afab856b3e3b80d945"
 dependencies = [
  "alloy-primitives",
  "serde",
@@ -336,13 +337,14 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c613222abd016e03ba548f41db938a2c99108b59c0c66ca105eab1b7a2e6b40a"
+checksum = "f96b3526fdd779a4bd0f37319cfb4172db52a7ac24cdbb8804b72091c18e1701"
 dependencies = [
  "alloy-primitives",
  "async-trait",
  "auto_impl",
+ "either",
  "elliptic-curve",
  "k256",
  "thiserror",
@@ -423,9 +425,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40e2f34fcd849676c8fe274a6e72f0664dfede7ce06d12daa728d2e72f1b4393"
+checksum = "5a8d762eadce3e9b65eac09879430c6f4fce3736cac3cac123f9b1bf435ddd13"
 dependencies = [
  "alloy-json-rpc",
  "base64",
@@ -442,9 +444,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-http"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e291c97c3c0ebb5d03c34e3a55c0f7c5bfa307536a2efaaa6fae4b3a4d09851"
+checksum = "20819c4cb978fb39ce6ac31991ba90f386d595f922f42ef888b4a18be190713e"
 dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
@@ -737,9 +739,9 @@ dependencies = [
 
 [[package]]
 name = "blst"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4378725facc195f1a538864863f6de233b500a8862747e7f165078a419d5e874"
+checksum = "47c79a94619fade3c0b887670333513a67ac28a6a7e653eb260bf0d4103db38d"
 dependencies = [
  "cc",
  "glob",
@@ -791,9 +793,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.13"
+version = "1.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7777341816418c02e033934a09f20dc0ccaf65a5201ef8a450ae0105a573fda"
+checksum = "0c3d1b2e905a3a7b00a6141adb0e4c0bb941d11caf55349d863942a1cc44e3c9"
 dependencies = [
  "shlex",
 ]
@@ -1052,9 +1054,9 @@ dependencies = [
 
 [[package]]
 name = "equivalent"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
@@ -1076,7 +1078,7 @@ dependencies = [
  "serde",
  "serde_json",
  "wavs-wasi-chain",
- "wit-bindgen-rt 0.38.0",
+ "wit-bindgen-rt 0.39.0",
  "wstd",
 ]
 
@@ -1899,9 +1901,9 @@ checksum = "945462a4b81e43c4e3ba96bd7b49d834c6f61198356aa858733bc4acf3cbe62e"
 
 [[package]]
 name = "openssl"
-version = "0.10.70"
+version = "0.10.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61cfb4e166a8bb8c9b55c500bc2308550148ece889be90f609377e58140f42c6"
+checksum = "5e14130c6a98cd258fdcb0fb6d744152343ff729cbfcb28c656a9d12b999fbcd"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -1931,9 +1933,9 @@ checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.105"
+version = "0.9.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b22d5b84be05a8d6947c7cb71f7c849aa0f112acd4bf51c2a7c1c988ac0a9dc"
+checksum = "8bb61ea9811cc39e3c2069f40b8b8e2e70d8569b361f879786cc7ed48b777cdd"
 dependencies = [
  "cc",
  "libc",
@@ -2577,9 +2579,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.13.2"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
+checksum = "7fcf8323ef1faaee30a44a340193b1ac6814fd9b7b4e88e9d4519a3e4abe1cfd"
 dependencies = [
  "serde",
 ]
@@ -2706,9 +2708,9 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"
-version = "3.16.0"
+version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38c246215d7d24f48ae091a2902398798e05d978b24315d6efbc00ede9a8bb91"
+checksum = "a40f762a77d2afa88c2d919489e390a12bdd261ed568e60cfa7e48d4e20f0d33"
 dependencies = [
  "cfg-if",
  "fastrand",
@@ -3121,9 +3123,9 @@ dependencies = [
 
 [[package]]
 name = "wavs-wasi-chain"
-version = "0.3.0-alpha4"
+version = "0.3.0-alpha5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96e9be8fcc823682ac0066dcf3074baaf68fe446542693f75797a2fb6002305b"
+checksum = "a8eb5ddb2a9f5132169e894272dd7c7819b02bccbd807726b4dda2b6ba43bfe3"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -3135,6 +3137,8 @@ dependencies = [
  "anyhow",
  "cfg-if",
  "futures-utils-wasm",
+ "http",
+ "serde",
  "serde_json",
  "tower-service",
  "wasi 0.14.1+wasi-0.2.3",
@@ -3278,15 +3282,6 @@ name = "wit-bindgen-rt"
 version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3268f3d866458b787f390cf61f4bbb563b922d091359f9608842999eaee3943c"
-dependencies = [
- "bitflags",
-]
-
-[[package]]
-name = "wit-bindgen-rt"
-version = "0.38.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed6f8d372a2d4a1227f2556e051cc24b2a5f15768d53451c84ff91e2527139e3"
 dependencies = [
  "bitflags",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,17 +14,17 @@ rust-version = "1.80.0"
 
 [workspace.dependencies]
 # WASI
-wit-bindgen-rt = {version = "0.38.0", features = ["bitflags"]}
-wit-bindgen = "0.38.0"
-wstd = "0.5.0"
-wasi = "0.13.3"
-wavs-wasi-chain = "0.3.0-alpha4"
+wit-bindgen-rt = {version = "0.39.0", features = ["bitflags"]}
+wit-bindgen = "0.39.0"
+wstd = "0.5.1"
+wasi = "0.14.1"
+wavs-wasi-chain = "0.3.0-alpha5"
 
 # Other
-serde = { version = "1.0.211", features = ["derive"] }
-serde_json = "1.0.127"
-anyhow = "1.0.90"
+serde = { version = "1.0.217", features = ["derive"] }
+serde_json = "1.0.138"
+anyhow = "1.0.95"
 
 ## Alloy
-alloy-sol-macro = { version = "0.8.15", features = ["json"]}
-alloy-sol-types = "0.8.20"
+alloy-sol-macro = { version = "0.8.13", features = ["json"]}
+alloy-sol-types = "0.8.13"

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ SERVICE_CONFIG='{"fuel_limit":100000000,"max_gas":5000000,"host_envs":[],"kv":[]
 
 # Define common variables
 CARGO=cargo
-WAVS_CMD ?= $(SUDO) docker run --rm --network host $$(test -f .env && echo "--env-file ./.env") -v $$(pwd):/data ghcr.io/lay3rlabs/wavs:0.3.0-alpha9 wavs-cli
+WAVS_CMD ?= $(SUDO) docker run --rm --network host $$(test -f .env && echo "--env-file ./.env") -v $$(pwd):/data ghcr.io/lay3rlabs/wavs:0.3.0-alpha10 wavs-cli
 ANVIL_PRIVATE_KEY?=0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
 RPC_URL?=http://localhost:8545
 SERVICE_MANAGER_ADDR?=`jq -r '.eigen_service_managers.local | .[-1]' .docker/deployments.json`

--- a/components/eth-price-oracle/src/bindings.rs
+++ b/components/eth-price-oracle/src/bindings.rs
@@ -5,7 +5,8 @@ pub type TriggerAction = wavs::worker::layer_types::TriggerAction;
 #[doc(hidden)]
 #[allow(non_snake_case)]
 pub unsafe fn _export_run_cabi<T: Guest>(arg0: *mut u8) -> *mut u8 {
-    #[cfg(target_arch = "wasm32")] _rt::run_ctors_once();
+    #[cfg(target_arch = "wasm32")]
+    _rt::run_ctors_once();
     let l0 = *arg0.add(0).cast::<*mut u8>();
     let l1 = *arg0.add(4).cast::<usize>();
     let len2 = l1;
@@ -607,11 +608,8 @@ pub mod host {
                                         let l7 = *ptr1.add(16).cast::<*mut u8>();
                                         let l8 = *ptr1.add(20).cast::<usize>();
                                         let len9 = l8;
-                                        let bytes9 = _rt::Vec::from_raw_parts(
-                                            l7.cast(),
-                                            len9,
-                                            len9,
-                                        );
+                                        let bytes9 =
+                                            _rt::Vec::from_raw_parts(l7.cast(), len9, len9);
                                         _rt::string_lift(bytes9)
                                     };
                                     Some(e)
@@ -625,11 +623,8 @@ pub mod host {
                                         let l11 = *ptr1.add(28).cast::<*mut u8>();
                                         let l12 = *ptr1.add(32).cast::<usize>();
                                         let len13 = l12;
-                                        let bytes13 = _rt::Vec::from_raw_parts(
-                                            l11.cast(),
-                                            len13,
-                                            len13,
-                                        );
+                                        let bytes13 =
+                                            _rt::Vec::from_raw_parts(l11.cast(), len13, len13);
                                         _rt::string_lift(bytes13)
                                     };
                                     Some(e)
@@ -695,11 +690,8 @@ pub mod host {
                                         let l7 = *ptr1.add(16).cast::<*mut u8>();
                                         let l8 = *ptr1.add(20).cast::<usize>();
                                         let len9 = l8;
-                                        let bytes9 = _rt::Vec::from_raw_parts(
-                                            l7.cast(),
-                                            len9,
-                                            len9,
-                                        );
+                                        let bytes9 =
+                                            _rt::Vec::from_raw_parts(l7.cast(), len9, len9);
                                         _rt::string_lift(bytes9)
                                     };
                                     Some(e)
@@ -713,11 +705,8 @@ pub mod host {
                                         let l11 = *ptr1.add(28).cast::<*mut u8>();
                                         let l12 = *ptr1.add(32).cast::<usize>();
                                         let len13 = l12;
-                                        let bytes13 = _rt::Vec::from_raw_parts(
-                                            l11.cast(),
-                                            len13,
-                                            len13,
-                                        );
+                                        let bytes13 =
+                                            _rt::Vec::from_raw_parts(l11.cast(), len13, len13);
                                         _rt::string_lift(bytes13)
                                     };
                                     Some(e)
@@ -731,11 +720,8 @@ pub mod host {
                                         let l15 = *ptr1.add(40).cast::<*mut u8>();
                                         let l16 = *ptr1.add(44).cast::<usize>();
                                         let len17 = l16;
-                                        let bytes17 = _rt::Vec::from_raw_parts(
-                                            l15.cast(),
-                                            len17,
-                                            len17,
-                                        );
+                                        let bytes17 =
+                                            _rt::Vec::from_raw_parts(l15.cast(), len17, len17);
                                         _rt::string_lift(bytes17)
                                     };
                                     Some(e)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ services:
 
   # The main instance all WAVS interaction will happen from
   wavs:
-    image: "ghcr.io/lay3rlabs/wavs:0.3.0-alpha9"
+    image: "ghcr.io/lay3rlabs/wavs:0.3.0-alpha10"
     container_name: "wavs"
     stop_signal: SIGKILL
     # depends_on: ["anvil"]
@@ -38,7 +38,7 @@ services:
       - "./.docker:/root/wavs/cli/"
 
   aggregator:
-    image: "ghcr.io/lay3rlabs/wavs:0.3.0-alpha9"
+    image: "ghcr.io/lay3rlabs/wavs:0.3.0-alpha10"
     container_name: "wavs-aggregator"
     stop_signal: SIGKILL
     depends_on: ["wavs"]
@@ -51,7 +51,7 @@ services:
     network_mode: "host"
 
   deploy-eigenlayer:
-    image: "ghcr.io/lay3rlabs/wavs:0.3.0-alpha9"
+    image: "ghcr.io/lay3rlabs/wavs:0.3.0-alpha10"
     container_name: "wavs-deploy-eigenlayer"
     depends_on: ["wavs", "aggregator"] # "anvil",
     restart: "no"
@@ -63,7 +63,7 @@ services:
     network_mode: "host"
 
   deploy-eigenlayer-service-manager:
-    image: "ghcr.io/lay3rlabs/wavs:0.3.0-alpha9"
+    image: "ghcr.io/lay3rlabs/wavs:0.3.0-alpha10"
     container_name: "wavs-deploy-service-manager"
     depends_on:
       deploy-eigenlayer:

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "dependencies": {
         "@openzeppelin/contracts": "^5.2.0",
-        "@wavs/solidity": "^0.3.0-alpha2",
+        "@wavs/solidity": "^0.3.0-alpha3",
         "forge-std": "github:foundry-rs/forge-std#v1.9.6"
       }
     },
@@ -17,9 +17,9 @@
       "license": "MIT"
     },
     "node_modules/@wavs/solidity": {
-      "version": "0.3.0-alpha2",
-      "resolved": "https://registry.npmjs.org/@wavs/solidity/-/solidity-0.3.0-alpha2.tgz",
-      "integrity": "sha512-twxVpRZ8EoIOO69dQh7WpzqBkKXQfQnmZK4BqBVoc4WKs95I6PrpveymRzS3dmdKAC2VZBWW7jg65s8sA6oiRQ==",
+      "version": "0.3.0-alpha3",
+      "resolved": "https://registry.npmjs.org/@wavs/solidity/-/solidity-0.3.0-alpha3.tgz",
+      "integrity": "sha512-1za5pCenH5UkFCe0SwzlYINwH3jsZGlO7nsIbTdQfJ7xNJicoAl9wTV1Fdh2Rzs0Q34V/jNt0VV7Bz2nNxkxlg==",
       "license": "MIT"
     },
     "node_modules/forge-std": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "@openzeppelin/contracts": "^5.2.0",
-    "@wavs/solidity": "^0.3.0-alpha2",
+    "@wavs/solidity": "^0.3.0-alpha3",
     "forge-std": "github:foundry-rs/forge-std#v1.9.6"
   }
 }

--- a/script/Deploy.s.sol
+++ b/script/Deploy.s.sol
@@ -5,7 +5,7 @@ import "forge-std/Script.sol";
 import {stdJson} from "forge-std/StdJson.sol";
 import {Strings} from "@openzeppelin-contracts/utils/Strings.sol";
 
-import {ILayerServiceManager} from "@wavs/interfaces/ILayerServiceManager.sol";
+import {IWavsServiceManager} from "@wavs/interfaces/IWavsServiceManager.sol";
 
 import {SimpleSubmit} from "../src/WavsSubmit.sol";
 import {SimpleTrigger} from "../src/WavsTrigger.sol";
@@ -27,7 +27,7 @@ contract DeployScript is Script {
     function run(string calldata serviceManagerAddr) public {
         vm.startBroadcast(privateKey);
 
-        SimpleSubmit submit = new SimpleSubmit(ILayerServiceManager(vm.parseAddress(serviceManagerAddr)));
+        SimpleSubmit submit = new SimpleSubmit(IWavsServiceManager(vm.parseAddress(serviceManagerAddr)));
         SimpleTrigger trigger = new SimpleTrigger();
 
         vm.stopBroadcast();

--- a/src/WavsSubmit.sol
+++ b/src/WavsSubmit.sol
@@ -1,19 +1,19 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-import {ILayerServiceManager} from "@wavs/interfaces/ILayerServiceManager.sol";
-import {ILayerServiceHandler} from "@wavs/interfaces/ILayerServiceHandler.sol";
+import {IWavsServiceManager} from "@wavs/interfaces/IWavsServiceManager.sol";
+import {IWavsServiceHandler} from "@wavs/interfaces/IWavsServiceHandler.sol";
 
 import {ITypes} from "./interfaces/ITypes.sol";
 
-contract SimpleSubmit is ILayerServiceHandler {
-    ILayerServiceManager private _serviceManager;
+contract SimpleSubmit is IWavsServiceHandler {
+    IWavsServiceManager private _serviceManager;
 
     mapping(ITypes.TriggerId => bool) validTriggers;
     mapping(ITypes.TriggerId => bytes) datas;
     mapping(ITypes.TriggerId => bytes) signatures;
 
-    constructor(ILayerServiceManager serviceManager) {
+    constructor(IWavsServiceManager serviceManager) {
         _serviceManager = serviceManager;
     }
 


### PR DESCRIPTION
This upgrades:

* `wavs-wasi-chain` to use the new http helpers
* `@wavs/solidity` to use the new interface naming
* overall Cargo.toml dependency bump