### PR TITLE
chore(ci): require single wavs image usage in the codebase

### DIFF
--- a/.github/single-wavs-image-verifier.bash
+++ b/.github/single-wavs-image-verifier.bash
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Define the pattern
 # Updated to handle semantic versions with suffixes (like -beta, -alpha, etc.)
@@ -15,7 +15,7 @@ main() {
         if [[ $file == lib/* ]]; then
             continue
         fi
-        if [[ $file == *$(basename $0)* ]]; then
+        if [[ $file == *$(basename $0) ]]; then
             continue
         fi
 

--- a/.github/single-wavs-image-verifier.sh
+++ b/.github/single-wavs-image-verifier.sh
@@ -1,0 +1,79 @@
+#!/bin/sh
+
+# Define the pattern
+# Updated to handle semantic versions with suffixes (like -beta, -alpha, etc.)
+GREP_PATTERN='ghcr\.io/lay3rlabs/wavs:(v?[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9]+)?|[a-zA-Z0-9-_./]+)'
+
+export DEBUGGING=${DEBUGGING:-false}
+
+main() {
+    # declare an empty array
+    matches_set=()
+
+    # iterate over all files not ignored by .gitignore
+    while read file; do
+        if [[ $file == lib/* ]]; then
+            continue
+        fi
+        if [[ $file == *$(basename $0)* ]]; then
+            continue
+        fi
+
+        found_docker=$(grep -P -o "$GREP_PATTERN" $file)
+        if [[ ! -z $found_docker ]]; then
+            # ensure found_docker is split on new lines to each their own array components (some files may have multiple references)
+            IFS=$'\n' read -rd '' -a found_docker_array <<< "$found_docker"
+            for i in "${found_docker_array[@]}"; do
+                if [[ $DEBUGGING == "true" ]]; then
+                    echo "Found in $file: $i"
+                fi
+
+                # check if the array already contains the item, if it does, skip adding it
+                if [[ " ${matches_set[@]} " =~ " ${i} " ]]; then
+                    continue
+                fi
+
+                matches_set+=("$i")
+            done
+        fi
+    done < <(git ls-files --cached --others --exclude-standard)
+
+    if [[ ${#matches_set[@]} -eq 1 ]]; then
+        echo "Only found a single image: ${matches_set[0]}, success"
+        exit 0
+    else
+        echo "Found multiple docker images in the codebase:"
+        for i in "${matches_set[@]}"; do
+            echo "$i"
+        done
+        echo "Please ensure only a single wavs docker image is being referenced in the files"
+        exit 1
+    fi
+}
+
+test_data() {
+    # Example test data
+    TEST_DATA="
+    Running container ghcr.io/lay3rlabs/wavs:0.3.0-beta
+    Pulling ghcr.io/lay3rlabs/wavs:latest
+    Found ghcr.io/lay3rlabs/wavs:0.1.0
+    Invalid: docker.io/other/image:1.0
+    Using ghcr.io/lay3rlabs/wavs:sha-abc123
+    ghcr.io/lay3rlabs/wavs:rc.1.0.0
+    Pulling ghcr.io/lay3rlabs/wavs:latest
+    Found ghcr.io/lay3rlabs/wavs:0.1.0
+    Invalid: docker.io/other/image:1.0
+    Using ghcr.io/lay3rlabs/wavs:sha-abc123
+    ghcr.io/lay3rlabs/wavs:rc.1.0.0
+    ghcr.io/lay3rlabs/wavs:0.3.0-beta
+    ghcr.io/lay3rlabs/wavs:1.0.0-alpha
+    "
+
+    # Find all matches_set with line numbers (-n) and print the pattern at the top
+    echo "Pattern being used: $GREP_PATTERN"
+    echo -e "\nmatches_set found:"
+    echo "$TEST_DATA" | grep -P -o "$GREP_PATTERN"
+}
+
+# test_data
+main

--- a/.github/workflows/wavs-image-version-verifier.yml
+++ b/.github/workflows/wavs-image-version-verifier.yml
@@ -14,8 +14,11 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v4
 
+    - name: Install bash
+      run: sudo apt-get install bash
+
     - name: Make script executable
-      run: chmod +x .github/single-wavs-image-verifier.sh
+      run: chmod +x .github/single-wavs-image-verifier.bash
 
     - name: Run script
-      run: sh .github/single-wavs-image-verifier.sh
+      run: bash .github/single-wavs-image-verifier.bash

--- a/.github/workflows/wavs-image-version-verifier.yml
+++ b/.github/workflows/wavs-image-version-verifier.yml
@@ -1,0 +1,21 @@
+name: Check WAVS Image Version
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  script:
+    runs-on: ubuntu-latest
+    env:
+      DEBUGGING: true
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Make script executable
+      run: chmod +x .github/single-wavs-image-verifier.sh
+
+    - name: Run script
+      run: sh .github/single-wavs-image-verifier.sh


### PR DESCRIPTION
closes #53 

Searches the entire codebase for non gitignored files to ensure that only 1 docker wavs image is used. if not, it fails and lets the users know all images that are used.