### PR TITLE
Add upgrade script

### DIFF
--- a/tools/upgrade.sh
+++ b/tools/upgrade.sh
@@ -5,27 +5,37 @@ set -e
 # Take first argument as the version to upgrade to
 VERSION=$1
 
-# TODO: make this conditional, just for docker
-SUDO="sudo"
+if [ -z "$VERSION" ]; then
+    echo "Usage: $0 <version>"
+    exit 1
+fi
+if 
+
+# conditional sudo, just for docker
+if groups | grep -q docker; then 
+  SUDO="";
+else
+  SUDO="sudo";
+fi
 
 # pull this version to ensure we have it
 if ! ${SUDO} docker pull ghcr.io/lay3rlabs/wavs:${VERSION}; then
-    echo "Failed to pull ghcr.io/lay3rlabs/wavs:${VERSION}"
+    echo "Invalid WAVS version, cannot pull ghcr.io/lay3rlabs/wavs:${VERSION}"
     exit 1
 fi
 
 # Update Makefile
-sed -i "s/ghcr.io\/lay3rlabs\/wavs:[^\s]+/ghcr.io\/lay3rlabs\/wavs:${VERSION}/g" Makefile
+sed -E -i "s/ghcr.io\/lay3rlabs\/wavs:[^ ]+/ghcr.io\/lay3rlabs\/wavs:${VERSION}/g" Makefile
 
 # Update docker-compose.yml
-sed -i "s/   image: \"ghcr.io\/lay3rlabs\/wavs:[^\"]+/   image: \"ghcr.io\/lay3rlabs\/wavs:${VERSION}/g" docker-compose.yml
+sed -E -i "s/ghcr.io\/lay3rlabs\/wavs:[^\"]+/ghcr.io\/lay3rlabs\/wavs:${VERSION}/g" docker-compose.yml
 
 # Update Cargo.toml (for crates dependencies)
-sed -i "s/wavs-wasi-chain = \"[^\"]+/wavs-wasi-chain = \"${VERSION}/g" Cargo.toml
+sed -E -i "s/wavs-wasi-chain = \"[^\"]+/wavs-wasi-chain = \"${VERSION}/g" Cargo.toml
 
 # Update [package.metadata.component] in components/*/Cargo.toml (for wit)
-sed -i "s/wavs:worker\/layer-trigger-world@[^\"]+/wavs:worker\/layer-trigger-world@${VERSION}/g" components/*/Cargo.toml
+sed -E -i "s/wavs:worker\/layer-trigger-world@[^\"]+/wavs:worker\/layer-trigger-world@${VERSION}/g" components/*/Cargo.toml
 
-# Rebuild with cargo component build
-
- 
+# Rebuild with cargo component build in order to update bindings and Cargo.lock
+rm components/*/src/bindings.rs
+make wasi-build

--- a/tools/upgrade.sh
+++ b/tools/upgrade.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+set -e
+
+# Take first argument as the version to upgrade to
+VERSION=$1
+
+# TODO: make this conditional, just for docker
+SUDO="sudo"
+
+# pull this version to ensure we have it
+if ! ${SUDO} docker pull ghcr.io/lay3rlabs/wavs:${VERSION}; then
+    echo "Failed to pull ghcr.io/lay3rlabs/wavs:${VERSION}"
+    exit 1
+fi
+
+# Update Makefile
+sed -i "s/ghcr.io\/lay3rlabs\/wavs:[^\s]+/ghcr.io\/lay3rlabs\/wavs:${VERSION}/g" Makefile
+
+# Update docker-compose.yml
+sed -i "s/   image: \"ghcr.io\/lay3rlabs\/wavs:[^\"]+/   image: \"ghcr.io\/lay3rlabs\/wavs:${VERSION}/g" docker-compose.yml
+
+# Update Cargo.toml (for crates dependencies)
+sed -i "s/wavs-wasi-chain = \"[^\"]+/wavs-wasi-chain = \"${VERSION}/g" Cargo.toml
+
+# Update [package.metadata.component] in components/*/Cargo.toml (for wit)
+sed -i "s/wavs:worker\/layer-trigger-world@[^\"]+/wavs:worker\/layer-trigger-world@${VERSION}/g" components/*/Cargo.toml
+
+# Rebuild with cargo component build
+
+ 


### PR DESCRIPTION
This is designed both for template developers to easily bump to a new version of WAVS, as well as template users to update an existing project to a newer version of WAVS.

It updates all the docker images, wavs-wasi-chain import and the wit files to the given version. It does a simple check if the proper docker image exists to see if this is a valid version.

Example usage: `./tools/upgrade.sh 0.3.0`

This should help both devs and users when they upgrade. Happy for more feedback on this script and ways to improve it. Heavily inspired by my work in https://github.com/Lay3rLabs/wavs-foundry-template/pull/71

One limitation is that it uses the same version for docker image, crates.io, and wit definitions.
The first two should be generated from the same tags, but the wit definitions might not follow (eg. only 0.3.0 for wit, not 0.3.1, 0.3.2 as with the code).

Not sure how to handle that well? This should work as is for major version bumps (0.3.0 -> 0.4.0) but not patches (0.4.0 -> 0.4.1)