### PR TITLE
refactor: unbundle make commands for foundry cmds

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -92,11 +92,14 @@ jobs:
 
     - name: Run tests
       run: |
-        make deploy-contracts
+        export SERVICE_MANAGER_ADDR=`make get-eigen-service-manager-from-deploy`
+        forge script ./script/Deploy.s.sol ${SERVICE_MANAGER_ADDR} --sig "run(string)" --rpc-url http://localhost:8545 --broadcast
         sleep 2
         TRIGGER_EVENT="NewTrigger(bytes)" make deploy-service
         sleep 2
-        COIN_MARKET_CAP_ID=1 make trigger-service
+        export COIN_MARKET_CAP_ID=1
+        export SERVICE_TRIGGER_ADDR=`make get-trigger-from-deploy`
+        forge script ./script/Trigger.s.sol ${SERVICE_TRIGGER_ADDR} ${COIN_MARKET_CAP_ID} --sig "run(string,string)" --rpc-url http://localhost:8545 --broadcast -v 4
         sleep 2
 
     # `strings | grep BTC` verifies the output contains BTC from the price oracle example

--- a/Makefile
+++ b/Makefile
@@ -78,14 +78,12 @@ start-all: clean-docker setup-env
 	@rm --interactive=never .docker/*.json || true
 	@bash -ec 'anvil & anvil_pid=$$!; trap "kill -9 $$anvil_pid 2>/dev/null" EXIT; $(SUDO) docker compose up; wait'
 
-## deploy-contracts: deploying the contracts | SERVICE_MANAGER_ADDR, RPC_URL
-deploy-contracts:
-# `sudo chmod 0666 .docker/deployments.json`
-	@forge script ./script/Deploy.s.sol ${SERVICE_MANAGER_ADDR} --sig "run(string)" --rpc-url $(RPC_URL) --broadcast
-
 ## get-service-handler: getting the service handler address from the script deploy
 get-service-handler-from-deploy:
 	@jq -r '.service_handler' "./.docker/script_deploy.json"
+
+get-eigen-service-manager-from-deploy:
+	@jq -r '.eigen_service_managers.local | .[-1]' .docker/deployments.json
 
 ## get-trigger: getting the trigger address from the script deploy
 get-trigger-from-deploy:
@@ -103,10 +101,6 @@ deploy-service:
 	--trigger-address "${SERVICE_TRIGGER_ADDR}" \
 	--submit-address "${SERVICE_SUBMISSION_ADDR}" \
 	--service-config ${SERVICE_CONFIG}
-
-## trigger-service: triggering the service | SERVICE_TRIGGER_ADDR, COIN_MARKET_CAP_ID, RPC_URL
-trigger-service:
-	@forge script ./script/Trigger.s.sol ${SERVICE_TRIGGER_ADDR} ${COIN_MARKET_CAP_ID} --sig "run(string,string)" --rpc-url $(RPC_URL) --broadcast -v 4
 
 ## show-result: showing the result | SERVICE_TRIGGER_ADDR, SERVICE_SUBMISSION_ADDR, RPC_URL
 show-result:

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ forge init --template Lay3rLabs/wavs-foundry-template my-wavs
 Install the required packages to build the Solidity contracts. This project supports both [submodules](./.gitmodules) and [npm packages](./package.json).
 
 ```bash
-# Install packages
+# Install packages (npm & submodules)
 make setup
 
 # Build the contracts
@@ -155,8 +155,8 @@ make start-all
 Upload your service's trigger and submission contracts. The trigger contract is where WAVS will watch for events, and the submission contract is where the AVS service operator will submit the result on chain.
 
 ```bash
-# Run `./script/Deploy.s.sol`
-make deploy-contracts
+export SERVICE_MANAGER_ADDR=`make get-eigen-service-manager-from-deploy`
+forge script ./script/Deploy.s.sol ${SERVICE_MANAGER_ADDR} --sig "run(string)" --rpc-url http://localhost:8545 --broadcast
 ```
 
 > [!TIP]
@@ -176,7 +176,9 @@ TRIGGER_EVENT="NewTrigger(bytes)" make deploy-service
 Anyone can now call the [trigger contract](./src/contracts/WavsTrigger.sol) which emits the trigger event WAVS is watching for from the previous step. WAVS then calls the service and saves the result on-chain.
 
 ```bash
-COIN_MARKET_CAP_ID=1 make trigger-service
+export COIN_MARKET_CAP_ID=1
+export SERVICE_TRIGGER_ADDR=`make get-trigger-from-deploy`
+forge script ./script/Trigger.s.sol ${SERVICE_TRIGGER_ADDR} ${COIN_MARKET_CAP_ID} --sig "run(string,string)" --rpc-url http://localhost:8545 --broadcast -v 4
 ```
 
 ## Show the result

--- a/docs/tutorial/6-run-service.mdx
+++ b/docs/tutorial/6-run-service.mdx
@@ -36,27 +36,9 @@ With the chain and WAVS running, you can deploy and run your service.
 Open a new terminal and run the following command from the root of your project to upload your Service's Trigger and Submission contracts:
 
 ```bash
-make deploy-contracts
+export SERVICE_MANAGER_ADDR=`make get-eigen-service-manager-from-deploy`
+forge script ./script/Deploy.s.sol ${SERVICE_MANAGER_ADDR} --sig "run(string)" --rpc-url http://localhost:8545 --broadcast
 ```
-
-This command uses the script located in [`script/Deploy.s.sol`](https://github.com/Lay3rLabs/wavs-foundry-template/tree/v0.3.0-rc1/script/Deploy.s.sol) to deploy your contracts.
-
-<Callout title="Deployed addresses" type="info">
-
-View your deployed trigger address:
-
-```bash
-make get-trigger-from-deploy
-```
-
-View your deployed submission address:
-
-```bash
-make get-service-handler-from-deploy
-```
-
-</Callout>
-
 
 ## Deploy your service to WAVS
 
@@ -94,7 +76,9 @@ Running this command will execute [`/script/Trigger.s.sol`](https://github.com/L
 
 
 ```bash
-COIN_MARKET_CAP_ID=1 make trigger-service
+export COIN_MARKET_CAP_ID=1
+export SERVICE_TRIGGER_ADDR=`make get-trigger-from-deploy`
+forge script ./script/Trigger.s.sol ${SERVICE_TRIGGER_ADDR} ${COIN_MARKET_CAP_ID} --sig "run(string,string)" --rpc-url http://localhost:8545 --broadcast -v 4
 ```
 
 ## Show the result
@@ -107,5 +91,3 @@ make show-result
 ```
 
 Congratulations, you've just made a simple Bitcoin price oracle service using WAVS!
-
-


### PR DESCRIPTION
## Summary

ref: #68

Feedback from a few initial devs has been that the `make` command abstraction is too much, which was originally decided on [here in slack](https://lay3r.slack.com/archives/C07LTKJMP0A/p1739254584019279).

Going forward developers want to see the raw execution, abstract some, but not the entire process flow. WAVS abstraction will remain for now until the new 0.4 deploy-service-raw ability with JSON is added.