### PR TITLE
chore: jco verification

### DIFF
--- a/components/js-eth-price-oracle/Makefile
+++ b/components/js-eth-price-oracle/Makefile
@@ -9,16 +9,20 @@ check-package:
 		wkg get reecepbcups:wavs-testing@0.4.0-alpha.2 --overwrite --format wasm --output $(WAVS_PACKAGE).wasm; \
 	fi
 
+# if @bytecodealliance/jco is not installed, then run npm i here
+check-jco:
+	@npx jco --version || npm i
+
 # converts the entire .wasm package into a single .wit file, easily consumable by the jco command
 convert-wasm-to-wit:
 	@wasm-tools component wit $(WAVS_PACKAGE).wasm -o $(WAVS_PACKAGE).wit
 
 ## build-bindings: building the WAVS bindings
-build-bindings: check-package
+build-bindings: check-jco check-package
 	@npx jco types $(WAVS_PACKAGE).wasm --out-dir out/
 
 ## wasi-build: building the WAVS wasi component
-wasi-build: build-bindings convert-wasm-to-wit
+wasi-build: check-jco build-bindings convert-wasm-to-wit
 	@echo "Building component: js_eth_price_oracle"
 	@npx tsc --outDir out/ --target es6 --strict --module preserve index.ts
 	@npx esbuild ./index.js --bundle --outfile=out/out.js --platform=node --format=esm


### PR DESCRIPTION
## Summary

TS package likes to throw errors if `npm i` is not run, do this for the user vs showing a nasty error