### PR TITLE
Containerized Claude Code

### DIFF
--- a/.claude/Dockerfile.claude
+++ b/.claude/Dockerfile.claude
@@ -1,63 +1,59 @@
-FROM node:20
+# Use multi-stage build for a smaller final image
+FROM node:20-slim AS base
 
-# Install basic development tools and iptables/ipset
-RUN apt update && apt install -y less \
-  git \
-  procps \
-  sudo \
-  fzf \
-  zsh \
-  man-db \
-  unzip \
-  gnupg2 \
-  gh \
-  aggregate \
-  jq
+# Install only essential dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    git \
+    procps \
+    sudo \
+    fzf \
+    zsh \
+    wget \
+    ca-certificates \
+    gnupg2 \
+    jq \
+    unzip \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
 
-# Ensure default node user has access to /usr/local/share
-RUN mkdir -p /usr/local/share/npm-global && \
-  chown -R node:node /usr/local/share
-
+# Set up non-root user and directories
 ARG USERNAME=node
+RUN mkdir -p /usr/local/share/npm-global /workspace /home/node/.claude /commandhistory \
+    && touch /commandhistory/.bash_history \
+    && chown -R $USERNAME:$USERNAME /usr/local/share/npm-global /workspace /home/node/.claude /commandhistory
 
-# Persist bash history.
-RUN SNIPPET="export PROMPT_COMMAND='history -a' && export HISTFILE=/commandhistory/.bash_history" \
-  && mkdir /commandhistory \
-  && touch /commandhistory/.bash_history \
-  && chown -R $USERNAME /commandhistory
+# Install delta once
+RUN ARCH=$(dpkg --print-architecture) \
+    && wget -q "https://github.com/dandavison/delta/releases/download/0.18.2/git-delta_0.18.2_${ARCH}.deb" \
+    && dpkg -i "git-delta_0.18.2_${ARCH}.deb" \
+    && rm "git-delta_0.18.2_${ARCH}.deb"
 
-# Create workspace and config directories and set permissions
-RUN mkdir -p /workspace /home/node/.claude && \
-  chown -R node:node /workspace /home/node/.claude
+# Install additional utilities as needed (can be removed if not necessary)
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    less \
+    man-db \
+    gh \
+    aggregate \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
 
+USER $USERNAME
 WORKDIR /workspace
 
-RUN ARCH=$(dpkg --print-architecture) && \
-  wget "https://github.com/dandavison/delta/releases/download/0.18.2/git-delta_0.18.2_${ARCH}.deb" && \
-  sudo dpkg -i "git-delta_0.18.2_${ARCH}.deb" && \
-  rm "git-delta_0.18.2_${ARCH}.deb"
-
-# Set up non-root user
-USER node
-
-# Install global packages
+# Environment setup
 ENV NPM_CONFIG_PREFIX=/usr/local/share/npm-global
 ENV PATH=$PATH:/usr/local/share/npm-global/bin
+ENV SHELL=/bin/zsh
+ENV HISTFILE=/commandhistory/.bash_history
+ENV PROMPT_COMMAND='history -a'
 
-# Set the default shell to bash rather than sh
-ENV SHELL /bin/zsh
-
-# Default powerline10k theme
+# Install zsh configuration and global npm package in one layer
 RUN sh -c "$(wget -O- https://github.com/deluan/zsh-in-docker/releases/download/v1.2.0/zsh-in-docker.sh)" -- \
-  -t robbyrussell \
-  -p git \
-  -p fzf \
-  -a "source /usr/share/doc/fzf/examples/key-bindings.zsh" \
-  -a "source /usr/share/doc/fzf/examples/completion.zsh" \
-  -a "export PROMPT_COMMAND='history -a' && export HISTFILE=/commandhistory/.bash_history" \
-  -x
-
-# Install Claude
-RUN npm install -g @anthropic-ai/claude-code
-
-USER node
+    -t robbyrussell \
+    -p git \
+    -p fzf \
+    -a "source /usr/share/doc/fzf/examples/key-bindings.zsh" \
+    -a "source /usr/share/doc/fzf/examples/completion.zsh" \
+    -a "export PROMPT_COMMAND='history -a' && export HISTFILE=/commandhistory/.bash_history" \
+    -x \
+    && npm install -g @anthropic-ai/claude-code

--- a/.claude/Dockerfile.claude
+++ b/.claude/Dockerfile.claude
@@ -1,0 +1,63 @@
+FROM node:20
+
+# Install basic development tools and iptables/ipset
+RUN apt update && apt install -y less \
+  git \
+  procps \
+  sudo \
+  fzf \
+  zsh \
+  man-db \
+  unzip \
+  gnupg2 \
+  gh \
+  aggregate \
+  jq
+
+# Ensure default node user has access to /usr/local/share
+RUN mkdir -p /usr/local/share/npm-global && \
+  chown -R node:node /usr/local/share
+
+ARG USERNAME=node
+
+# Persist bash history.
+RUN SNIPPET="export PROMPT_COMMAND='history -a' && export HISTFILE=/commandhistory/.bash_history" \
+  && mkdir /commandhistory \
+  && touch /commandhistory/.bash_history \
+  && chown -R $USERNAME /commandhistory
+
+# Create workspace and config directories and set permissions
+RUN mkdir -p /workspace /home/node/.claude && \
+  chown -R node:node /workspace /home/node/.claude
+
+WORKDIR /workspace
+
+RUN ARCH=$(dpkg --print-architecture) && \
+  wget "https://github.com/dandavison/delta/releases/download/0.18.2/git-delta_0.18.2_${ARCH}.deb" && \
+  sudo dpkg -i "git-delta_0.18.2_${ARCH}.deb" && \
+  rm "git-delta_0.18.2_${ARCH}.deb"
+
+# Set up non-root user
+USER node
+
+# Install global packages
+ENV NPM_CONFIG_PREFIX=/usr/local/share/npm-global
+ENV PATH=$PATH:/usr/local/share/npm-global/bin
+
+# Set the default shell to bash rather than sh
+ENV SHELL /bin/zsh
+
+# Default powerline10k theme
+RUN sh -c "$(wget -O- https://github.com/deluan/zsh-in-docker/releases/download/v1.2.0/zsh-in-docker.sh)" -- \
+  -t robbyrussell \
+  -p git \
+  -p fzf \
+  -a "source /usr/share/doc/fzf/examples/key-bindings.zsh" \
+  -a "source /usr/share/doc/fzf/examples/completion.zsh" \
+  -a "export PROMPT_COMMAND='history -a' && export HISTFILE=/commandhistory/.bash_history" \
+  -x
+
+# Install Claude
+RUN npm install -g @anthropic-ai/claude-code
+
+USER node

--- a/.claude/docker-compose.claude.yml
+++ b/.claude/docker-compose.claude.yml
@@ -1,0 +1,18 @@
+services:
+  claude-code-sandbox:
+    build:
+      context: .
+      dockerfile: Dockerfile.claude
+    volumes:
+      - ..:/workspace:consistent
+      - claude-code-bashhistory:/commandhistory
+      - claude-code-config:/home/node/.claude
+    environment:
+      NODE_OPTIONS: --max-old-space-size=4096
+      CLAUDE_CONFIG_DIR: /home/node/.claude
+      POWERLEVEL9K_DISABLE_GITSTATUS: "true"
+    working_dir: /workspace
+
+volumes:
+  claude-code-bashhistory:
+  claude-code-config:

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,82 @@
+{
+  "terminal.integrated.profiles.osx": {
+    "Claude Code": {
+      // docker compose -f compose.claude.yml run --rm --remove-orphans -it claude-code-sandbox bash -c 'claude; exec'
+      "path": "docker",
+      "args": [
+        "compose",
+        "-f",
+        ".claude/docker-compose.claude.yml",
+        "run",
+        "--rm",
+        "--remove-orphans",
+        "-it",
+        "claude-code-sandbox",
+        "bash",
+        "-c",
+        "claude; exec"
+      ],
+      "icon": "robot",
+      "overrideName": true
+    },
+    "Claude Code (unrestricted)": {
+      // docker compose -f compose.claude.yml run --rm --remove-orphans -it claude-code-sandbox bash -c 'claude --dangerously-skip-permissions; exec'
+      "path": "docker",
+      "args": [
+        "compose",
+        "-f",
+        ".claude/docker-compose.claude.yml",
+        "run",
+        "--rm",
+        "--remove-orphans",
+        "-it",
+        "claude-code-sandbox",
+        "bash",
+        "-c",
+        "claude --dangerously-skip-permissions; exec"
+      ],
+      "icon": "robot",
+      "overrideName": true
+    }
+  },
+  "terminal.integrated.profiles.linux": {
+    "Claude Code": {
+      // docker compose -f compose.claude.yml run --rm --remove-orphans -it claude-code-sandbox bash -c 'claude; exec'
+      "path": "docker",
+      "args": [
+        "compose",
+        "-f",
+        ".claude/docker-compose.claude.yml",
+        "run",
+        "--rm",
+        "--remove-orphans",
+        "-it",
+        "claude-code-sandbox",
+        "bash",
+        "-c",
+        "claude; exec"
+      ],
+      "icon": "robot",
+      "overrideName": true
+    },
+    "Claude Code (unrestricted)": {
+      // docker compose -f compose.claude.yml run --rm --remove-orphans -it claude-code-sandbox bash -c 'claude --dangerously-skip-permissions; exec'
+      "path": "docker",
+      "args": [
+        "compose",
+        "-f",
+        ".claude/docker-compose.claude.yml",
+        "run",
+        "--rm",
+        "--remove-orphans",
+        "-it",
+        "claude-code-sandbox",
+        "bash",
+        "-c",
+        "claude --dangerously-skip-permissions; exec"
+      ],
+      "icon": "robot",
+      "overrideName": true
+    }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -292,4 +292,3 @@ npm run claude-code
 npm run claude-code:unrestricted
 ```
 
-You must have [Docker](https://www.docker.com/) installed.

--- a/README.md
+++ b/README.md
@@ -286,7 +286,7 @@ TRIGGER_ID=1 make show-result
 
 To spin up a sandboxed instance of [Claude Code](https://docs.anthropic.com/en/docs/agents-and-tools/claude-code/overview) in a Docker container that only has access to this project's files, run the following command:
 
-```bash
+```bash docci-ignore
 npm run claude-code
 # or with no restrictions (--dangerously-skip-permissions)
 npm run claude-code:unrestricted

--- a/README.md
+++ b/README.md
@@ -281,3 +281,15 @@ make get-trigger
 ```bash docci-delay-per-cmd=2 docci-output-contains="BTC"
 TRIGGER_ID=1 make show-result
 ```
+
+## Claude Code
+
+To spin up a sandboxed instance of [Claude Code](https://docs.anthropic.com/en/docs/agents-and-tools/claude-code/overview) in a Docker container that only has access to this project's files, run the following command:
+
+```bash
+npm run claude-code
+# or with no restrictions (--dangerously-skip-permissions)
+npm run claude-code:unrestricted
+```
+
+You must have [Docker](https://www.docker.com/) installed.

--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
     "lint:sol": "solhint 'src/**/*.sol' 'script/**/*.sol' 'test/**/*.sol'",
     "test": "forge test -vvv",
     "test:integration": "forge test --match-contract Integration -vvv",
-    "test:unit": "forge test --match-contract Unit -vvv"
+    "test:unit": "forge test --match-contract Unit -vvv",
+    "claude-code": "docker compose -f .claude/docker-compose.claude.yml run --rm --remove-orphans -it claude-code-sandbox bash -c 'claude; exec'",
+    "claude-code:unrestricted": "docker compose -f .claude/docker-compose.claude.yml run --rm --remove-orphans -it claude-code-sandbox bash -c 'claude --dangerously-skip-permissions; exec'"
   },
   "lint-staged": {
     "*.{js,css,md,ts,sol}": "forge fmt",


### PR DESCRIPTION
This adds a Dockerfile, docker compose file, VS Code terminal presets to launch Claude Code in the integrated terminal, and the commands `npm run claude-code` and `npm run claude-code:unrestricted`.

It simply spins up Claude Code in a container with only the current folder mounted in the container to sandbox Claude from the rest of the computer's filesystem. It does still have access to the internet, which I think people probably want. The docker container preserves command history and config across runs but destroys the container on exit to keep things clean.

We could move the `claude-code` scripts to the `Makefile` if we think it belongs there, but I think it makes more sense in the `package.json`.