### PR TITLE
fix zsh shell format error

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ cp .env.example .env
 # Create new operator
 cast wallet new-mnemonic --json > .docker/operator1.json
 export OPERATOR_MNEMONIC=`cat .docker/operator1.json | jq -r .mnemonic`
-export OPERATOR_PK=`cat .docker/operator1.json | jq -r .accounts[0].private_key`
+export OPERATOR_PK=`cat .docker/operator1.json | jq -r '.accounts[0].private_key'`
 
 make start-all
 ```


### PR DESCRIPTION
zsh on mac complains about the brackets not being quoted

```zsh
export OPERATOR_PK=`cat .docker/operator1.json | jq -r .accounts[0].private_key`
```

```
zsh: no matches found: .accounts[0].private_key
```