### PR TITLE
Update mnemonic in env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,7 +11,7 @@ WAVS_COSMOS_SUBMISSION_MNEMONIC="cosmos mnemonic here"
 
 # WAVS CLI
 WAVS_CLI_DATA=~/wavs/cli
-WAVS_CLI_COSMOS_CREDENTIAL="cosmos mnemonic here"
+WAVS_CLI_COSMOS_MNEMONIC="cosmos mnemonic here"
 WAVS_CLI_EVM_CREDENTIAL="test test test test test test test test test test test junk"
 WAVS_CLI_LOG_LEVEL="info, wavs_cli=info"
 


### PR DESCRIPTION
the env variable name needs to be WAVS_CLI_COSMOS_ MNEMONIC when creating a cosmos event trigger via cli or it will throw an error. 

example command:

```
wavs-cli service --file service.json workflow trigger --id 0196c4ff-76a7-76e2-bcc3-b92ada2a39b1 set-cosmos --address neutron1qlaq54uh9f52d3p66q77s6kt0k9ee3vasy8gkdkk3yvgezcs6zts0mkcv4 --chain-name neutron --event-type send_nft
```