### PR TITLE
feat(optional): `set-source-registry` for more public deployments

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,8 +218,22 @@ export SERVICE_TRIGGER_ADDR=`jq -r .deployedTo .docker/trigger.json`
 Deploy the compiled component with the contract information from the previous steps. Review the [makefile](./Makefile) for more details and configuration options.`TRIGGER_EVENT` is the event that the trigger contract emits and WAVS watches for. By altering `SERVICE_TRIGGER_ADDR` you can watch events for contracts others have deployed.
 
 ```bash docci-delay-per-cmd=3
+export COMPONENT_FILENAME=evm_price_oracle.wasm
+
+# === LOCAL ===
+export IS_TESTNET=false
+export WASM_DIGEST=$(make upload-component COMPONENT_FILENAME=$COMPONENT_FILENAME)
+
+# === TESTNET ===
+# ** Setup: https://wa.dev/account/credentials
+export IS_TESTNET=true
+export PKG_VERSION="0.1.0"
+export PKG_NAMESPACE=`warg info --namespaces | grep = | cut -d'=' -f1 | tr -d ' '`
+export PKG_NAME="${PKG_NAMESPACE}:evmpriceoraclerust"
+warg publish release --name ${PKG_NAME} --version ${PKG_VERSION} ./compiled/${COMPONENT_FILENAME} || true
+
 # Build your service JSON
-COMPONENT_FILENAME=evm_price_oracle.wasm AGGREGATOR_URL=http://127.0.0.1:8001 sh ./script/build_service.sh
+AGGREGATOR_URL=http://127.0.0.1:8001 sh ./script/build_service.sh
 
 # Upload service.json to IPFS
 ipfs_cid=`IPFS_ENDPOINT=http://127.0.0.1:5001 SERVICE_FILE=.docker/service.json make upload-to-ipfs`

--- a/components/golang-evm-price-oracle/README.md
+++ b/components/golang-evm-price-oracle/README.md
@@ -116,7 +116,17 @@ export SERVICE_TRIGGER_ADDR=`jq -r .deployedTo .docker/trigger.json`
 ## Deploy Service
 
 ```bash docci-delay-per-cmd=3
-COMPONENT_FILENAME=golang_evm_price_oracle.wasm sh ./script/build_service.sh
+
+export COMPONENT_FILENAME=golang_evm_price_oracle.wasm
+
+# === LOCAL ===
+export IS_TESTNET=false
+export WASM_DIGEST=$(make upload-component COMPONENT_FILENAME=$COMPONENT_FILENAME)
+
+# === TESTNET ===
+# - reference repo root README.md
+
+sh ./script/build_service.sh
 
 # Upload service.json to IPFS
 ipfs_cid=`IPFS_ENDPOINT=http://127.0.0.1:5001 SERVICE_FILE=.docker/service.json make upload-to-ipfs`

--- a/components/js-evm-price-oracle/README.md
+++ b/components/js-evm-price-oracle/README.md
@@ -85,8 +85,17 @@ export SERVICE_TRIGGER_ADDR=`jq -r .deployedTo .docker/trigger.json`
 Upload service
 
 ```bash docci-delay-per-cmd=2
+export COMPONENT_FILENAME=js_evm_price_oracle.wasm
+
+# === LOCAL ===
+export IS_TESTNET=false
+export WASM_DIGEST=$(make upload-component COMPONENT_FILENAME=$COMPONENT_FILENAME)
+
+# === TESTNET ===
+# - reference repo root README.md
+
 # Build your service JSON with optional overrides in the script
-COMPONENT_FILENAME=js_evm_price_oracle.wasm sh ./script/build_service.sh
+sh ./script/build_service.sh
 
 # Upload service.json to IPFS
 ipfs_cid=`IPFS_ENDPOINT=http://127.0.0.1:5001 SERVICE_FILE=.docker/service.json make upload-to-ipfs`

--- a/script/build_service.sh
+++ b/script/build_service.sh
@@ -12,7 +12,6 @@ sh ./build_service.sh
 - FILE_LOCATION: The save location of the configuration file
 - TRIGGER_ADDRESS: The address to trigger the service
 - SUBMIT_ADDRESS: The address to submit the service
-- COMPONENT_FILENAME: The filename of the component to upload (ignored if WASM_DIGEST is used)
 - WASM_DIGEST: The digest of the component to use that is already in WAVS
 - TRIGGER_EVENT: The event to trigger the service (e.g. "NewTrigger(bytes)")
 - FUEL_LIMIT: The fuel limit (wasm compute metering) for the service
@@ -24,11 +23,11 @@ sh ./build_service.sh
 FUEL_LIMIT=${FUEL_LIMIT:-1000000000000}
 MAX_GAS=${MAX_GAS:-5000000}
 FILE_LOCATION=${FILE_LOCATION:-".docker/service.json"}
-COMPONENT_FILENAME=${COMPONENT_FILENAME:-"evm_price_oracle.wasm"}
 TRIGGER_EVENT=${TRIGGER_EVENT:-"NewTrigger(bytes)"}
 TRIGGER_CHAIN=${TRIGGER_CHAIN:-"local"}
 SUBMIT_CHAIN=${SUBMIT_CHAIN:-"local"}
 AGGREGATOR_URL=${AGGREGATOR_URL:-""}
+IS_TESTNET=${IS_TESTNET:-"false"}
 # used in make upload-component
 WAVS_ENDPOINT=${WAVS_ENDPOINT:-"http://localhost:8000"}
 export DOCKER_DEFAULT_PLATFORM=linux/amd64
@@ -47,11 +46,9 @@ fi
 if [ -z "$SUBMIT_ADDRESS" ]; then
     SUBMIT_ADDRESS=`make get-submit-from-deploy`
 fi
-if [ -z "$WASM_DIGEST" ]; then
-    WASM_DIGEST=`make upload-component COMPONENT_FILENAME=$COMPONENT_FILENAME`
-    WASM_DIGEST=$(echo ${WASM_DIGEST} | cut -d':' -f2)
+if [[ "$WASM_DIGEST" == sha256:* ]]; then
+    WASM_DIGEST=${WASM_DIGEST#sha256:}
 fi
-
 # === Core ===
 
 TRIGGER_EVENT_HASH=`cast keccak ${TRIGGER_EVENT}`
@@ -71,7 +68,17 @@ if [ -n "$AGGREGATOR_URL" ]; then
 fi
 $BASE_CMD workflow submit --id ${WORKFLOW_ID} ${SUB_CMD} --address ${SUBMIT_ADDRESS} --chain-name ${SUBMIT_CHAIN} --max-gas ${MAX_GAS} > /dev/null
 
-$BASE_CMD workflow component --id ${WORKFLOW_ID} set-source-digest --digest ${WASM_DIGEST} > /dev/null
+if [ "$IS_TESTNET" = "false" ]; then
+    if [ -z "$WASM_DIGEST" ]; then
+        echo "WASM_DIGEST is not set. You must upload the component directly to the wavs instance."
+        echo "(( optionally: \`export IS_TESTNET=true\` and upload your component to the wa.dev registry ))."
+        exit 1
+    fi
+    $BASE_CMD workflow component --id ${WORKFLOW_ID} set-source-digest --digest ${WASM_DIGEST}
+else
+    # use the package directly, no need to upload component to the instance itself. 
+    $BASE_CMD workflow component --id ${WORKFLOW_ID} set-source-registry --version ${PKG_VERSION} --package ${PKG_NAME}
+fi
 
 $BASE_CMD workflow component --id ${WORKFLOW_ID} permissions --http-hosts '*' --file-system true > /dev/null
 $BASE_CMD workflow component --id ${WORKFLOW_ID} time-limit --seconds 30 > /dev/null

--- a/wavs.toml
+++ b/wavs.toml
@@ -23,6 +23,8 @@ log_level = ["info", "wavs=debug"]
 # The IPFS gateway URL used to access IPFS content over HTTP.
 # ipfs_gateway = "https://ipfs.io/ipfs/"
 
+registry_domain = "wa.dev"
+
 # ----------------------------
 # Chain configurations
 # ----------------------------
@@ -93,8 +95,6 @@ gas_denom = "untrn"
 # WAVS specific settings
 # ----------------------------
 [wavs]
-# Registry domain
-registry_domain = "wa.dev"
 
 cors_allowed_origins = [
     "https://lay3rlabs.github.io/*",


### PR DESCRIPTION
## Summary

This is a half way point of https://github.com/Lay3rLabs/wavs-foundry-template/pull/141. The goal is to not require WAVS to be started yet while we still get everything setup. Only the aggregator should be (optionally) on at this point

This new flow gets closer to the desired.

With PR 141, the most ideal flow here is that we do not use `set-source-digest` at all (this can be removed from WAVS entirely), and instead we use a local wasi/oci registry that mimics wa.dev. In doing this we keep the same workflow for both, and avoid API keys

As this stands, it still requires wavs to start before on local. Making it so we can not re-use the same workflow for both local & testnet