### PR TITLE
feat: local docker wasi registry

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,6 +20,8 @@ WAVS_AGGREGATOR_DATA=~/wavs/aggregator
 WAVS_AGGREGATOR_CREDENTIAL="test test test test test test test test test test test junk"
 WAVS_AGGREGATOR_HD_INDEX=0
 
+WKG_OCI_INSECURE=localhost,127.0.0.1
+
 # == Testnet ==
 # Replace with your RPC URL
 RPC_URL=https://holesky.drpc.org

--- a/script/build_service.sh
+++ b/script/build_service.sh
@@ -27,12 +27,11 @@ TRIGGER_EVENT=${TRIGGER_EVENT:-"NewTrigger(bytes)"}
 TRIGGER_CHAIN=${TRIGGER_CHAIN:-"local"}
 SUBMIT_CHAIN=${SUBMIT_CHAIN:-"local"}
 AGGREGATOR_URL=${AGGREGATOR_URL:-""}
-IS_TESTNET=${IS_TESTNET:-"false"}
 # used in make upload-component
 WAVS_ENDPOINT=${WAVS_ENDPOINT:-"http://localhost:8000"}
 export DOCKER_DEFAULT_PLATFORM=linux/amd64
 
-BASE_CMD="docker run --rm --network host -w /data -v $(pwd):/data ghcr.io/lay3rlabs/wavs:0.4.0-beta.5 wavs-cli service --json true --home /data --file /data/${FILE_LOCATION}"
+BASE_CMD="docker run --rm --network host -w /data -e WKG_OCI_INSECURE=localhost,127.0.0.1 -v $(pwd):/data ghcr.io/lay3rlabs/wavs:0.4.0-beta.5 wavs-cli service --json true --home /data --file /data/${FILE_LOCATION}"
 
 if [ -z "$SERVICE_MANAGER_ADDRESS" ]; then
     echo "SERVICE_MANAGER_ADDRESS is not set. Please set it to the address of the service manager."
@@ -45,9 +44,6 @@ if [ -z "$TRIGGER_ADDRESS" ]; then
 fi
 if [ -z "$SUBMIT_ADDRESS" ]; then
     SUBMIT_ADDRESS=`make get-submit-from-deploy`
-fi
-if [[ "$WASM_DIGEST" == sha256:* ]]; then
-    WASM_DIGEST=${WASM_DIGEST#sha256:}
 fi
 # === Core ===
 
@@ -68,17 +64,7 @@ if [ -n "$AGGREGATOR_URL" ]; then
 fi
 $BASE_CMD workflow submit --id ${WORKFLOW_ID} ${SUB_CMD} --address ${SUBMIT_ADDRESS} --chain-name ${SUBMIT_CHAIN} --max-gas ${MAX_GAS} > /dev/null
 
-if [ "$IS_TESTNET" = "false" ]; then
-    if [ -z "$WASM_DIGEST" ]; then
-        echo "WASM_DIGEST is not set. You must upload the component directly to the wavs instance."
-        echo "(( optionally: \`export IS_TESTNET=true\` and upload your component to the wa.dev registry ))."
-        exit 1
-    fi
-    $BASE_CMD workflow component --id ${WORKFLOW_ID} set-source-digest --digest ${WASM_DIGEST}
-else
-    # use the package directly, no need to upload component to the instance itself. 
-    $BASE_CMD workflow component --id ${WORKFLOW_ID} set-source-registry --version ${PKG_VERSION} --package ${PKG_NAME}
-fi
+$BASE_CMD workflow component --id ${WORKFLOW_ID} set-source-registry --version ${PKG_VERSION} --package ${PKG_NAME} --domain ${WASI_REGISTRY}
 
 $BASE_CMD workflow component --id ${WORKFLOW_ID} permissions --http-hosts '*' --file-system true > /dev/null
 $BASE_CMD workflow component --id ${WORKFLOW_ID} time-limit --seconds 30 > /dev/null

--- a/wavs.toml
+++ b/wavs.toml
@@ -23,7 +23,7 @@ log_level = ["info", "wavs=debug"]
 # The IPFS gateway URL used to access IPFS content over HTTP.
 # ipfs_gateway = "https://ipfs.io/ipfs/"
 
-registry_domain = "wa.dev"
+registry_domain = "127.0.0.1:8090"
 
 # ----------------------------
 # Chain configurations


### PR DESCRIPTION
old: #141 

ref https://docs.google.com/document/d/1RKWQHckHPGzGu6cRc9pQQEyXEWX8WnkXoHQ5yhBLmYU/edit?tab=t.0

## Summary

Adds support for a local WASI registry so that the build_service.sh uses the same `set-source-registry`. This allows wavs to not be started yet & opt in to happen later